### PR TITLE
[1.1.4] Allow setting explicit base path for watched files

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ const watchSass = (globs, options = {}) => {
   options.warn = options.warn || warn
   const tree = new ImportTree(options.cwd, globs, options.warn).build()
   const handler = new EventHandler(tree)
-  return watch(globs)
+  return watch(globs, { base: options.base })
     .pipe(fn(function (vinyl) {
       this.push(vinyl)
       handler[vinyl.event](vinyl, this)


### PR DESCRIPTION
We had a case where the source glob could be different depending on build config (for example `src/frontend/*/*/css/*.scss` vs. `src/frontend/namespace/themename/css/*.scss`), but the destination directory is always the same `skin`. Without the base option those different globs would result in files being written in different directories, but setting the base option in `gulp.src` as `src` fixed this. However it wasn't yet possible here in `gulp-watch-sass`.   

Setting the base path is possible in `gulp-watch`, so I thought it would make sense to also allow it here. I'm not sure about the usefulness of the other options in `gulp-watch`, but @sp00m can probably say if the whole `options` object could be passed into `gulp-watch`.